### PR TITLE
fix(dll): 刷新后文字消失修复 + fix(server): UAC提权与服务端闪退修复

### DIFF
--- a/ServerUI/MainForm.DllExt.cs
+++ b/ServerUI/MainForm.DllExt.cs
@@ -459,6 +459,9 @@ public partial class MainForm : AntdUI.Window
 
             tbl.ResumeLayout(true);
             tbl.PerformLayout();
+            // v2.1-4 修复: 重建后强制整表与滚动容器重绘（同下方常规分支）
+            tbl.Invalidate();
+            (tbl.Parent as AntdUI.In.Panel)?.Invalidate(true);
             return;
         }
 
@@ -485,6 +488,7 @@ public partial class MainForm : AntdUI.Window
             {
                 Text = IsGameNative(p.File) ? p.Name + "（必选）" : p.Name,
                 Font = new Font("Microsoft YaHei UI", 9.5f * k, FontStyle.Bold),
+                ForeColor = Style.Get(Colour.Text),   // 显式主题前景色：刷新重建后不依赖 Label 默认取色（避免文字失踪）
                 Dock = DockStyle.Fill,
                 TextAlign = ContentAlignment.MiddleLeft
             };
@@ -638,6 +642,10 @@ public partial class MainForm : AntdUI.Window
 
         tbl.ResumeLayout(true);
         tbl.PerformLayout();
+        // v2.1-4 修复: 重建后强制整表与滚动容器重绘
+        // （AntdUI 自绘控件刷新重建后偶发不重绘 → 文字不显示但按钮/开关仍在）
+        tbl.Invalidate();
+        (tbl.Parent as AntdUI.In.Panel)?.Invalidate(true);
     }
 
     /*

--- a/ServerUI/Services/ServerService.cs
+++ b/ServerUI/Services/ServerService.cs
@@ -198,12 +198,19 @@ public class ServerService
         var bat = Path.Combine(baseDir, "start-server.bat");
         if (!File.Exists(bat)) return;  // 脚本不存在（可能是首次使用，需要先更新）
 
-        // 【v1.85-1 修复】DfoServer 窗口隐藏失败问题
-        // 根因: DfoServer 由 start-server.bat 在共享控制台中启动，
-        //       MainWindowHandle 归属 cmd.exe 而非 DfoServer.exe，
-        //       事后 ShowWindow() 无法隐藏 DfoServer 窗口。
-        // 方案: CreateNoWindow = true，进程启动时直接不创建控制台窗口，
-        //       这是隐藏控制台程序窗口最可靠的方式。
+        // 【v2.1-3 修复】服务端由 AUM 启动会闪退（手动启动正常）
+        // 根因（双重）:
+        //   1. 权限: app.manifest 为 asInvoker —— 普通启动时 AUM 与子进程均为非管理员,
+        //      DfoServer 需要管理员权限（写数据/绑定端口等）→ 启动即闪退;
+        //      手动"以管理员身份运行"bat 时才有管理员权限 → 正常。
+        //   2. 隐藏方式: v1.85-1 为隐藏窗口用 CreateNoWindow=true, 服务端在无真实控制台
+        //      环境下启动, 与手动双击（有真实控制台）环境不一致, 加剧闪退。
+        // 方案:
+        //   1. app.manifest 改 requireAdministrator —— AUM 强制管理员运行,
+        //      整个进程树（含 DfoServer）自动获得管理员权限 = "所有操作按管理员运行";
+        //   2. CreateNoWindow = false —— 与手动双击完全一致的运行环境（真实控制台）;
+        //   3. 快速隐藏 —— Start 后立即轮询 MainWindowHandle, 控制台出现即隐藏
+        //      （cmd 与 DfoServer 共享同一控制台, 隐藏 cmd 主窗口即隐藏整个共享控制台）。
         _batProcess = new Process
         {
             StartInfo = new ProcessStartInfo
@@ -211,7 +218,7 @@ public class ServerService
                 FileName = bat,
                 WorkingDirectory = baseDir,
                 UseShellExecute = false,
-                CreateNoWindow = true   // 启动时即隐藏，比事后 ShowWindow 更可靠
+                CreateNoWindow = false   // 与手动双击一致, 保证 DfoServer 有真实控制台
             },
             EnableRaisingEvents = true
         };
@@ -227,6 +234,31 @@ public class ServerService
         };
 
         _batProcess.Start();
+
+        // v2.1-3 快速隐藏: 控制台窗口出现后立即隐藏（不必等 Play 的 10 秒兜底任务）
+        // cmd 与 DfoServer 共享同一控制台: 隐藏 cmd 主窗口即隐藏整个共享控制台;
+        // 进程已退出时 MainWindowHandle 访问会抛异常, 由 try/catch 兜底。
+        if (!_batProcess.HasExited)
+        {
+            _ = System.Threading.Tasks.Task.Run(() =>
+            {
+                try
+                {
+                    var deadline = DateTime.UtcNow.AddSeconds(5);
+                    while (DateTime.UtcNow < deadline)
+                    {
+                        System.Threading.Thread.Sleep(60);
+                        var hwnd = _batProcess.MainWindowHandle;
+                        if (hwnd != IntPtr.Zero)
+                        {
+                            ShowWindow(hwnd, 0);
+                            break;
+                        }
+                    }
+                }
+                catch { }
+            });
+        }
     }
 
     /*

--- a/ServerUI/app.manifest
+++ b/ServerUI/app.manifest
@@ -5,7 +5,7 @@
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
-        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false"/>
       </requestedPrivileges>
     </security>
   </trustInfo>

--- a/ServerUI/app.manifest(Win7).xml
+++ b/ServerUI/app.manifest(Win7).xml
@@ -5,7 +5,7 @@
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
-        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false"/>
       </requestedPrivileges>
     </security>
   </trustInfo>


### PR DESCRIPTION
# Pull Request: v2.1 热修复 —— DLL 页刷新文字失踪 & 服务端提权/隐藏优化

---

## 问题一：DLL 扩展页刷新后文字失踪（按钮/开关仍在）

### 现象

在 DLL 扩展页执行刷新后，受管插件行的名称文字全部消失，但按钮和开关控件（有边框/背景色块）仍然正常显示，用户无法识别插件条目。

### 根因分析

AntdUI 自绘控件在运行期重建后存在两条失效路径：

1. **默认取色失效** — 受管插件行名称 `Label` 之前未显式设置 `ForeColor`，完全依赖 AntdUI 的“主题默认取色”（`Colour.DefaultColor.Get`）。刷新重建后的新控件在主题取色链上偶发失效，导致文字被绘制为与背景同色/空色，视觉上“消失”。
2. **重建后不重绘** — 执行 `SuspendLayout` → `Dispose` 重建 → `ResumeLayout` 后，AntdUI 自绘控件偶发不触发重绘。文字未被渲染，但按钮/开关（有独立边框和背景色块）依然可见，形成“文字全失踪但按钮还在”的现象。

### 修复方案（`MainForm.DllExt.cs` / `RebuildDllRows`）

- 受管行名称 `Label` 补显式设置 `ForeColor = Style.Get(Colour.Text)`，直接使用主题前景色，不再依赖默认取色链。
- 在常规分支与“未安装”分支尾部统一增加强制重绘兜底逻辑： ```csharp tbl.Invalidate(); (tbl.Parent as AntdUI.In.Panel)?.Invalidate(true); ``` 同时刷新表格及其滚动容器，确保自绘控件重绘触发。
- 保留既有的 `k`（`DeviceDpi / 96`）缩放补偿逻辑，确保刷新后文字大小与首次加载一致。

### 补充说明

此前已修复的“自定义扩展行名字失踪”（`Color.Empty` 全透明）问题、统一字号 `9.5F`、加宽名称列等改动均保留。本次修复后，受管行/表头/自定义行全部显式着色 + 强制重绘，从机制上消除“刷新后文字消失”问题。

---

## 问题二：服务端启动闪退 / 快速隐藏不生效

### 现象

- 普通双击启动 `AUM` 后，服务端子进程（`cmd → DfoServer`）启动即闪退；
- 需手动右键“以管理员身份运行”才能正常工作；
- “快速隐藏”功能未能如预期快速隐藏控制台窗口。

### 根因分析

1. **提权不足**：`app.manifest` 中 `<requestedExecutionLevel>` 为 `asInvoker`，普通双击时 AUM 以非管理员权限运行，子进程继承该权限。而 `DfoServer` 需要管理员权限（写入数据、绑定端口等），启动即闪退。手动右键管理员运行则正常。
2. **隐藏延迟**：原有隐藏逻辑需等待 10 秒后才执行，且受权限影响，未能及时响应。
3. **跨框架兼容**：代码中使用了 `Environment.TickCount64`，该 API 仅在 .NET Core 中可用，`net48` 编译报错。

### 修复方案

| 模块 | 改动 |
|------|------|
| **`app.manifest`** | `<requestedExecutionLevel level="asInvoker" />` → `level="requireAdministrator" />`。AUM 启动即弹 UAC 提权，整棵进程树自动以管理员权限运行，所有操作（启动服务端、调整系统时间等）均无需再手动右键管理员运行。同步更新 `app.manifest(Win7).xml`。 | | **`ServerService.cs` / 快速隐藏** | `CreateNoWindow` 保持 `false`（与手动双击同环境，避免闪退）。隐藏逻辑不再等待 10 秒：`Start()` 后立即轮询 `MainWindowHandle`，控制台窗口一出现即调用 `ShowWindow(hwnd, 0)` 隐藏，约 0.5 秒内完成。`cmd` 与 `DfoServer` 共享同一控制台，隐藏主窗口即整个控制台一并隐藏。保留原有 10/15 秒兜底任务。 | | **跨框架兼容** | `Environment.TickCount64` → `DateTime.UtcNow`，解决 `net48` 编译报错。 |

---

## 影响范围

- DLL 扩展页 UI 渲染与刷新逻辑
- 应用程序启动提权行为（UAC）
- 服务端启动与控制台隐藏流程
- 工程配置：`app.manifest` / `app.manifest(Win7).xml`

---

## 测试建议

1. **DLL 页刷新**：执行多次刷新操作，确认所有插件名称正常显示，按钮/开关位置与文字一致，缩放后字体大小不变。
2. **提权验证**：普通双击启动 AUM，确认 UAC 弹窗出现，授予权限后服务端子进程正常启动，无闪退。
3. **快速隐藏**：启动服务端后，观察控制台窗口是否在 0.5 秒左右自动隐藏，且 `DfoServer` 后台正常运行。
4. **兼容性**：在 .NET Framework 4.8 环境下编译通过，无 `TickCount64` 相关报错。

---