### PR TITLE
修复进度条显示问题

### DIFF
--- a/ServerUI/MainForm.Server.cs
+++ b/ServerUI/MainForm.Server.cs
@@ -32,31 +32,23 @@ public partial class MainForm : AntdUI.Window
         _pt = new Timer { Interval = 500 };
         _pt.Tick += (s, e) =>
         {
-            // ===== 伪进度算法: 进度条永不卡死 =====
-            // 1. 收到真实阶段标记(_stepTarget 前进) → 大步追赶, 制造"刚完成一个阶段"的跳跃感
-            // 2. 追平目标但更新未结束 → 缓慢蠕动逼近 90 (剩余量按比例递减, 永不完成)
-            // 3. 超过 90 → 极慢蠕动 + 在 94~95 区间轻微"呼吸"波动, 让用户知道仍在工作
-            // 真实进度标记(##PROGRESS##/[N/5])仍会驱动 _stepTarget, 完成时 OD 直接跳 100%
+            // ===== v2.15 真实里程碑跟随 =====
+            // _stepTarget 只由 update.ps1 的真实节点驱动(源预检8/下载20/同步30/
+            // 编译产物落盘62·72·80/日志87-95), 显示值永不越过最新真实节点:
+            //   未达目标: 按 gap*0.16/500ms 平滑收敛, 不越过目标
+            //   已达目标: 仅做 0.03%/tick 的阶段内缓推(上限 里程碑+4, 绝对上限 97), 表明仍在工作
+            // 100% 只由完成回调 (OD) 设置
             if (_pv < _stepTarget)
             {
                 var gap = _stepTarget - _pv;
-                _pv += Math.Max(1.5f, gap * 0.35f);
+                _pv += Math.Min(gap, Math.Max(0.35f, gap * 0.16f));
                 if (_pv > _stepTarget) _pv = _stepTarget;
             }
-            else if (_pv < 90)
+            else if (_pv < Math.Min(_stepTarget + 4f, 97f))
             {
-                var rem = 90 - _pv;
-                _pv += Math.Max(0.3f, rem * 0.02f);
+                _pv += 0.03f;
             }
-            else
-            {
-                var rem = 95 - _pv;
-                if (rem > 1f)
-                    _pv += Math.Max(0.15f, rem * 0.025f);   // 90→94: 约15秒到达, 持续可见推进
-                else
-                    _pv = 94.2f + (float)(Math.Sin(Environment.TickCount / 400.0) + 1) * 0.4f; // 94.2~95.0 呼吸
-            }
-            pb.Value = Math.Min(_pv, 100f) / 100f;   // AntdUI Progress.Value 为 0-1 比率
+            pb.Value = Math.Min(_pv, 99f) / 100f;   // AntdUI Progress.Value 为 0-1 比率
             lbPg.Text = "更新进度: " + (int)_pv + "%";
         };
 
@@ -1186,9 +1178,9 @@ public partial class MainForm : AntdUI.Window
             {
                 BeginInvokeUi(() =>
                 {
-                    if (pct > _stepTarget && pct <= 95) _stepTarget = pct;
-                    _pv = Math.Max(_pv, pct - 3);   // 贴近真实进度, 剩余交给蠕动
-                    pb.Value = Math.Min(_pv, 95f) / 100f;
+                    if (pct > _stepTarget && pct <= 97) _stepTarget = pct;
+                    _pv = Math.Max(_pv, pct - 5);   // 真实节点到达: 轻微贴近后平滑收敛
+                    pb.Value = Math.Min(_pv, 97f) / 100f;
                     lbPg.Text = "更新进度: " + (int)_pv + "%";
                     ProgressHook?.Invoke((int)_pv);     // 转发到经典模式窗口
                 });
@@ -1215,12 +1207,12 @@ public partial class MainForm : AntdUI.Window
         var sm = System.Text.RegularExpressions.Regex.Match(m, @"\[(\d)/5\]");
         if (sm.Success && int.TryParse(sm.Groups[1].Value, out var step))
         {
-            int target = step switch { 1 => 5, 2 => 25, 3 => 55, 4 => 85, 5 => 93, _ => -1 };
+            int target = step switch { 1 => 5, 2 => 10, 3 => 30, 4 => 55, 5 => 85, _ => -1 };
             BeginInvokeUi(() =>
             {
-                if (target >= 0) _stepTarget = target;
-                if (_pv < _stepTarget - 8) _pv = _stepTarget - 8;   // 大步跳到阶段附近, 剩余交给蠕动
-                pb.Value = Math.Min(_pv, 95f) / 100f;
+                if (target > _stepTarget) _stepTarget = target;   // v2.15: 只前进, 防旧标记回拉
+                if (_pv < _stepTarget - 5) _pv = _stepTarget - 5;
+                pb.Value = Math.Min(_pv, 97f) / 100f;
                 lbPg.Text = "更新进度: " + (int)_pv + "%";
                 ProgressHook?.Invoke((int)_pv);     // 转发到经典模式窗口
             });


### PR DESCRIPTION
**关键约束（实测验证过）**：编译在嵌套 runspace 里跑、输出缓冲到结束才回传（我做了机制测试：runspace 的 Write-Host 到不了 stdout），所以编译进度不能用“里面直接发标记”实现。改用**主作用域轮询真实产物信号**——编译期间主作用码本来就要等编译结束，把阻塞等待改成轮询循环，盯三个“产物文件被重写”的真实信号：

| 里程碑 | 真实含义 | 判定 |
|---|---|---|
| 5 / 8 | 准备 / 源预检完成 | 原有 + 新增 |
| 20 | 下载+校验全部完成 | 原有 |
| 30 / 55 | 文件同步开始 / 编译开始 | 原有 |
| **62** | **服务端 restore 完成** | `obj\project.assets.json` 被重写（mtime 晚于编译开始） | | **72** | **服务端 publish 落盘** | `DfoServer.exe` 被重写 | | **80** | **GM publish 落盘** | `DfoGmTool.exe` 被重写 | | 85 → 87~95 | 日志拉取开始 / 分页（重排后单调，不再倒退） | 原有（重校准） |

新标记序列：**5 → 8 → 20 → 30 → 55 → 62 → 72 → 80 → 85 → 87…95 → 100**，全部对应实际发生的事件。

**GUI 算法同步重写**：
- 显示值**永不越过最新真实里程碑**（未达目标时按 gap×0.16/500ms 平滑收敛，不再大跳）
- 追平后只做 0.03%/tick 的阶段内缓推（上限里程碑+4、绝对上限 97）——表明程序没死，但绝不谎报跨阶段进度
- **去掉了 94~95 呼吸动画和“蠕到 90”的虚假推进**；100% 只由真实的完成回调设置
- `[N/5]` 映射重校准为 5/10/30/55/85 且只前进，防旧标记回拉