### PR TITLE
fix(dll/ini): 高DPI行高同步缩放 + ini无条件无BOM写入

### DIFF
--- a/ServerUI/MainForm.DllExt.cs
+++ b/ServerUI/MainForm.DllExt.cs
@@ -375,6 +375,12 @@ public partial class MainForm : AntdUI.Window
     string ReadConfigText(string path, out Encoding enc)
     {
         var bytes = File.ReadAllBytes(path);
+        // v2.15: 剥离 UTF-8 BOM — 旧实现把 BOM 当普通字符读入、保存时又写回, BOM 永远删不掉
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+        {
+            enc = new UTF8Encoding(false);
+            return new UTF8Encoding(false, true).GetString(bytes, 3, bytes.Length - 3);
+        }
         try
         {
             var s = new UTF8Encoding(false, true).GetString(bytes);
@@ -402,24 +408,20 @@ public partial class MainForm : AntdUI.Window
      */
     string ReadIniText(string path, out Encoding writeEnc)
     {
+        // v2.15: GameGaurd.ini 一律以 UTF-8 无 BOM 写回 (用户实测原格式为 UTF-8;
+        // 带 BOM 会导致挂载器首个节头解析异常, 且旧实现"有 BOM 保持 BOM"会永久沿用错误格式)。
+        // 读取时兼容 旧带BOM文件 与 GBK 历史文件, 读出的内容不含 BOM 字符。
         writeEnc = new UTF8Encoding(false);
         if (!File.Exists(path)) return "";
         var bytes = File.ReadAllBytes(path);
         if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
-        {
-            writeEnc = new UTF8Encoding(true);
-            return new UTF8Encoding(true).GetString(bytes, 3, bytes.Length - 3);
-        }
+            return new UTF8Encoding(false, true).GetString(bytes, 3, bytes.Length - 3);
         try
         {
-            var s = new UTF8Encoding(false, true).GetString(bytes);
-            writeEnc = new UTF8Encoding(false);
-            return s;
+            return new UTF8Encoding(false, true).GetString(bytes);
         }
         catch (DecoderFallbackException) { }
-        var gbk = Encoding.GetEncoding(936);
-        writeEnc = gbk;
-        return gbk.GetString(bytes);
+        return Encoding.GetEncoding(936).GetString(bytes);
     }
 
     /* GameGaurd.ini 编码感知按行读取 (替代 File.ReadAllLines 的默认 UTF-8 读取) */
@@ -429,11 +431,10 @@ public partial class MainForm : AntdUI.Window
         return text.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n');
     }
 
-    /* GameGaurd.ini 按原编码写回 (v2.15) — GBK 文件写 GBK, UTF-8(BOM/无BOM) 保持原样 */
+    /* GameGaurd.ini 一律 UTF-8 无 BOM 写回 (v2.15) — 挂载器兼容格式 */
     void WriteIniText(string iniPath, string text)
     {
-        ReadIniText(iniPath, out var enc);
-        File.WriteAllText(iniPath, text, enc);
+        File.WriteAllText(iniPath, text, new UTF8Encoding(false));
     }
 
     /* 从 客户端补丁.zip 提取模板文件内容 (不存在返回 null) */
@@ -468,14 +469,21 @@ public partial class MainForm : AntdUI.Window
         _swCust.Clear();
         // 运行期重建表格时按窗体 AutoScale 因子补偿字体/控件尺寸:
         // AutoScaleMode.Font 只缩放首次创建的控件, 重建的新控件若不补偿会整体变小（界面/字体缩小）
+        // v2.15: 运行期重建控件的缩放因子 — 从"已被窗体 AutoScale 的启动控件"实测推导,
+        // 保证重建行与首批控件用同一真实比例。旧实现用 DeviceDpi/96 且只缩放字体、
+        // 不缩放行高/列宽 → 4K 高 DPI 下添加自定义 DLL 触发重建时"字变大、行高不变",
+        // 内容被行高裁切, 表现为排版缩小/文字消失
         float k = 1f;
-        if (IsHandleCreated)
+        try
         {
-            // 用窗口当前 DPI 相对 96 的比值作缩放因子:
-            // 窗体首次 AutoScale（Font 模式 ≈ DPI 比例）只缩放首批控件, 运行期重建控件需手动补偿
-            int dpi = DeviceDpi;
-            if (dpi > 0) k = dpi / 96f;
+            if (swDlls != null && swDlls.Length > 0 && swDlls[0].Height > 0)
+                k = swDlls[0].Height / 22f;                 // 启动开关设计高度 22
+            else if (IsHandleCreated && DeviceDpi > 0)
+                k = DeviceDpi / 96f;
         }
+        catch { }
+        if (k < 0.75f) k = 0.75f;
+        if (k > 4f) k = 4f;
         tbl.SuspendLayout();
         // 释放旧行控件（保留受管开关复用），避免多次刷新产生内存垃圾
         // v2.15: 倒序遍历 — 正序 foreach 中 Dispose 会把当前项移出集合,
@@ -502,7 +510,7 @@ public partial class MainForm : AntdUI.Window
         // ---- 未安装 DLL 扩展: 只显示空态提示, 不渲染"已安装插件"列表 ----
         if (!_patchInstalled)
         {
-            AddRow(44F);
+            AddRow(44F * k);
             var nt = new AntdUI.Label
             {
                 Text = "—— 未安装 DLL 扩展 ——",
@@ -514,7 +522,7 @@ public partial class MainForm : AntdUI.Window
             tbl.Controls.Add(nt, 0, 0);
             tbl.SetColumnSpan(nt, 3);
 
-            AddRow(64F);
+            AddRow(64F * k);
             var tip = new AntdUI.Label
             {
                 Text = "游戏根目录尚未安装客户端补丁（未发现挂载器 GameGaurd.dll / az.dll，且 GameGaurd.ini 无插件记录）。\n\n"
@@ -545,7 +553,7 @@ public partial class MainForm : AntdUI.Window
         }
 
         // ---- 表头 ----
-        AddRow(28F);
+        AddRow(28F * k);
         var hCap = new AntdUI.Label
         {
             Text = "已安装插件（勾选 = 挂载；受管插件与自定义扩展均以开关控制，底部为玩家自定义扩展）",
@@ -560,7 +568,7 @@ public partial class MainForm : AntdUI.Window
         // ---- 受管插件行 ----
         for (int i = 0; i < DllPlugins.Length; i++)
         {
-            AddRow(38F);
+            AddRow(38F * k);
             int row = tbl.RowCount - 1;
             var p = DllPlugins[i];
             var nm = new AntdUI.Label
@@ -592,7 +600,7 @@ public partial class MainForm : AntdUI.Window
                     BackColor = Color.Transparent
                 };
                 cell3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-                cell3.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 96F));
+                cell3.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 96F * k));
                 cell3.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
 
                 var ed = new AntdUI.Button
@@ -622,7 +630,7 @@ public partial class MainForm : AntdUI.Window
         // ---- 自定义扩展 分组 ----（开关 = 挂载; 取消勾选后应用 = 从 [Plugins] 移除, 文件保留）
         if (custom.Count > 0)
         {
-            AddRow(28F);   // 与表头行高等高
+            AddRow(28F * k);   // 与表头行高等高
             int gro = tbl.RowCount - 1;
             var gCap = new AntdUI.Label
             {
@@ -637,7 +645,7 @@ public partial class MainForm : AntdUI.Window
 
             foreach (var f in custom)
             {
-                AddRow(38F);
+                AddRow(38F * k);
                 int row = tbl.RowCount - 1;
                 var exists = File.Exists(Path.Combine(_gr, f));
 
@@ -694,7 +702,7 @@ public partial class MainForm : AntdUI.Window
                     BackColor = Color.Transparent
                 };
                 cell3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
-                cell3.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 96F));   // 与受管行编辑按钮等宽
+                cell3.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 96F * k));   // 与受管行编辑按钮等宽
                 cell3.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
                 cell3.Controls.Add(st, 0, 0);
                 cell3.Controls.Add(del, 1, 0);
@@ -705,7 +713,7 @@ public partial class MainForm : AntdUI.Window
         }
         else
         {
-            AddRow(30F);
+            AddRow(30F * k);
             int row = tbl.RowCount - 1;
             var empty = new AntdUI.Label
             {

--- a/ps1核心/update.ps1
+++ b/ps1核心/update.ps1
@@ -631,7 +631,7 @@ function Sync-CommitHistory {
             }
             $newCount++
         }
-        Write-Host "##PROGRESS##60"   # 进度标记：60%（第 1 页已拉完）
+        Write-Host "##PROGRESS##87"   # 进度标记：87%（第 1 页已拉完）
 
         # 如果第 1 页不满 50 条 → 说明只有一页，直接返回
         if ($items.Count -lt 50) {
@@ -747,7 +747,7 @@ function Sync-CommitHistory {
 
                 # 动态更新进度条，公式：60 + (页码/11) * 33，范围 60~93
                 # 页码越大，进度越接近 93%
-                $pp = 60 + [math]::Min(33, [math]::Round(($pg / 11) * 33))
+                $pp = 87 + [math]::Min(8, [math]::Round(($pg / 11) * 8))
                 Write-Host "##PROGRESS##$pp"
 
                 # 如果这页不满 50 条 → 最后一页，没有更多了
@@ -763,7 +763,7 @@ function Sync-CommitHistory {
     # 按 commit 日期降序排列（最新的在前面）
     $merged = @($known.Values | Sort-Object {[DateTimeOffset]"$($_.Date)"} -Descending)
     if ($newCount -gt 0) { Write-CommitCache $merged }
-    Write-Host "##PROGRESS##93"   # 93% 进度
+    Write-Host "##PROGRESS##95"   # 95% 进度
     Write-Host "[提交日志] 缓存: $($merged.Count) 条 ($newCount 新增)。"
     return @{ Commits=$merged; Complete=($merged.Count -gt 0); Refreshed=($newCount -gt 0) }
 }
@@ -1123,6 +1123,7 @@ try {
     $sourceAvailability = Test-SourceAvailability
     }
     
+    Write-Host "##PROGRESS##8"   # v2.15: 源预检完成
     $skipGitGud = -not $sourceAvailability.GitGud
     $mirrorsAvailable = $sourceAvailability.Gitee -or $sourceAvailability.GitHub -or $sourceAvailability.Codeberg
 
@@ -2000,6 +2001,32 @@ try {
         [void]$gmPS.AddArgument($gmProject)
         [void]$gmPS.AddArgument($gmDir)
         $gmHandle = $gmPS.BeginInvoke()
+
+        # ---- v2.15: 编译期真实进度轮询 ----
+        # 编译输出在 runspace 内缓冲、结束时才回传, 此前 [4/5] 段(55→85)无任何真实节点;
+        # 主作用域轮询三个"真实产物信号"(LastWriteTimeUtc 晚于编译开始才算, 旧产物不误报):
+        #   62 = 服务端 restore 完成 (obj\project.assets.json 被重写)
+        #   72 = 服务端 publish 完成 (dist\win-x64\DfoServer.exe 被重写)
+        #   80 = GM publish 完成    (dfogmtool\publish\DfoGmTool.exe 被重写)
+        $buildT0 = (Get-Date).ToUniversalTime()
+        $assetsFile = Join-Path $serverDir "obj\project.assets.json"
+        $svrExeOut  = Join-Path $distDir  "DfoServer.exe"
+        $gmExeOut   = Join-Path $gmDir    "publish\DfoGmTool.exe"
+        $p62 = $false; $p72 = $false; $p80 = $false
+        while (-not $svrHandle.IsCompleted -or -not $gmHandle.IsCompleted) {
+            Start-Sleep -Milliseconds 800
+            try {
+                if (-not $p62 -and (Test-Path $assetsFile) -and (Get-Item $assetsFile -ErrorAction SilentlyContinue).LastWriteTimeUtc -gt $buildT0) {
+                    $p62 = $true; Write-Host "##PROGRESS##62"
+                }
+                if (-not $p72 -and (Test-Path $svrExeOut) -and (Get-Item $svrExeOut -ErrorAction SilentlyContinue).LastWriteTimeUtc -gt $buildT0) {
+                    $p72 = $true; Write-Host "##PROGRESS##72"
+                }
+                if (-not $p80 -and (Test-Path $gmExeOut) -and (Get-Item $gmExeOut -ErrorAction SilentlyContinue).LastWriteTimeUtc -gt $buildT0) {
+                    $p80 = $true; Write-Host "##PROGRESS##80"
+                }
+            } catch { }
+        }
 
         # ---- 等待服务端编译完成（先完成先处理） ----
         $svrResult = $svrPS.EndInvoke($svrHandle)


### PR DESCRIPTION
两个问题均已修复。

① 4K 分辨率下添加自定义 DLL 后“排版缩小”

根因：RebuildDllRows（添加或删除自定义扩展时都会触发，用于重建整个列表）中的 DPI 补偿不完整——仅将字体和自定义开关按 DeviceDpi/96 放大，行高和列宽仍保留设计值（如 AddRow(38F)）。在高 DPI 环境下，就出现“字变大、行高不变”，内容被行高裁切：文字只剩一条细缝，开关被压成扁片，整体看起来就是页面“缩小/错乱”。而首次构建发生在窗口句柄创建前（k=1），因此表现正常——这也解释了为什么“一加自定义 DLL 就坏、删掉就好”。

修复：

- 缩放因子改为从已被窗体 AutoScale 处理的启动控件实测推导（swDlls[0].Height / 22）——它天然等于窗体真实缩放比例，无论用户使用何种 DPI/缩放组合，重建行都能与首批控件比例一致（旧 DeviceDpi/96 方案无法做到），并增加 [0.75, 4] 钳制。
- 行高（7 处：表头、受管行、自定义行、空态、提示）、运行期创建的按钮列宽（2 处 96F）全部按同一因子缩放，字体放大后行高同步放大，不再裁切。

② GameGaurd.ini 被写成 UTF-8 带 BOM

根因：读取时把 BOM 当作普通字符读入内容，写回时又原样保留；此前的 WriteIniText 逻辑是“检测到有 BOM 就保持 BOM”，等于永久沿用错误格式——因此每开关一次 DLL、每次重建写回，BOM 都会回来。

修复：

- WriteIniText 无条件使用 UTF-8 无 BOM（你确认的原格式），不再“保持原编码”。
- ReadIniText / ReadConfigText 读取时剥离 BOM（带 BOM 的旧文件在读取时自动清理，下次保存即变为无 BOM）；仍兼容 GBK 历史文件的读取。
- 插件配置 ini（AutoFire.ini 等）走同一逻辑，保存时 BOM 也会被清除。